### PR TITLE
refactor: 레이지 로딩 적용 취소

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,14 +1,11 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { lazy, Suspense } from 'react';
-import Spinner from '@/components/Spinner/Spinner';
 import App from '@/App';
 import ErrorPage from '@/pages/ErrorPage/ErrorPage';
 import MainPage from '@/pages/MainPage/MainPage';
-
-const AboutPage = lazy(() => import('@/pages/AboutPage/AboutPage'));
-const ServicesPage = lazy(() => import('@/pages/ServicesPage/ServicesPage'));
-const GalleryPage = lazy(() => import('@/pages/GalleryPage/GalleryPage'));
-const ContactPage = lazy(() => import('@/pages/ContactPage/ContactPage'));
+import AboutPage from '@/pages/AboutPage/AboutPage';
+import ServicesPage from '@/pages/ServicesPage/ServicesPage';
+import GalleryPage from '@/pages/GalleryPage/GalleryPage';
+import ContactPage from '@/pages/ContactPage/ContactPage';
 
 const router = createBrowserRouter([
   {
@@ -22,35 +19,19 @@ const router = createBrowserRouter([
       },
       {
         path: 'about',
-        element: (
-          <Suspense fallback={<Spinner />}>
-            <AboutPage />
-          </Suspense>
-        ),
+        element: <AboutPage />,
       },
       {
         path: 'services',
-        element: (
-          <Suspense fallback={<Spinner />}>
-            <ServicesPage />
-          </Suspense>
-        ),
+        element: <ServicesPage />,
       },
       {
         path: 'gallery',
-        element: (
-          <Suspense fallback={<Spinner />}>
-            <GalleryPage />
-          </Suspense>
-        ),
+        element: <GalleryPage />,
       },
       {
         path: 'contact',
-        element: (
-          <Suspense fallback={<Spinner />}>
-            <ContactPage />
-          </Suspense>
-        ),
+        element: <ContactPage />,
       },
     ],
   },


### PR DESCRIPTION
- js 청크가 페이지 별로 나뉘어 각 페이지에서 로드하는 청크의 양은 줄어들었으나, 실질적인 로드 속도에서(기존 청크의 크기가 그렇게 크지 않기 때문인 듯) 그다지 큰 효과를 보지 못했고, 레이지 로딩을 구현하기 위해서는 fallback을 사용해야 하는데 fallback을 스피너로 사용하면 ux에서 다운그레이드 되는 느낌이 들어 롤백하기로 결정.